### PR TITLE
Add "Signal processing" to list of algorithms

### DIFF
--- a/doc/src/Draft.do.txt
+++ b/doc/src/Draft.do.txt
@@ -235,7 +235,7 @@ The algorithms and tools listed here reflect to various degrees the previously d
 
 === Central algorithms ===
 The following mathematical formulations of problems from the physical sciences play a prominent role and should be reflected in the way we teach physics:
- * rdinary differential equations
+ * Ordinary differential equations
    o Euler, modified Euler, Verlet and Runge-Kutta methods with applications to problems in electromagnetism, methods for theoretical physics, quantum mechanics and mechanics.
  * Partial differential equations
    o Diffusion in one and two dimensions (statistical physics), wave equation in one and two dimensions (mechanics, electromagnetism, quantum mechanics, methods for theoretical physics) and Laplace's and Poisson's equations (electromagnetism).

--- a/doc/src/Draft.do.txt
+++ b/doc/src/Draft.do.txt
@@ -235,7 +235,7 @@ The algorithms and tools listed here reflect to various degrees the previously d
 
 === Central algorithms ===
 The following mathematical formulations of problems from the physical sciences play a prominent role and should be reflected in the way we teach physics:
- * Ordinary differential equations
+ * rdinary differential equations
    o Euler, modified Euler, Verlet and Runge-Kutta methods with applications to problems in electromagnetism, methods for theoretical physics, quantum mechanics and mechanics.
  * Partial differential equations
    o Diffusion in one and two dimensions (statistical physics), wave equation in one and two dimensions (mechanics, electromagnetism, quantum mechanics, methods for theoretical physics) and Laplace's and Poisson's equations (electromagnetism).
@@ -244,7 +244,9 @@ The following mathematical formulations of problems from the physical sciences p
  * Statistical analysis, random numbers, random walks, probability distributions, Monte Carlo integration and Metropolis algorithm. Applications to statistical physics and laboratory courses.
  * Linear Algebra and eigenvalue problems. 
    o Gaussian elimination, LU-decomposition, eigenvalue solvers, and iterative methods like  Jacobi or Gauss-Seidel for systems of linear equations. Important for several courses, classical mechanics, methods of theoretical physics, electromagnetism and quantum mechanics.
- * Root finding and interpolation techniques, used in methods for theoretical physics, quantum mechanics, electromagnetism and mechanics.
+ * Signal processing
+   o Discrete (fast) Fourier transforms, Lagrange/spline/Fourier interpolation, numeric convolutions & circulant matrices, filtering. Applications in electromagnetics, quantum mechanics, and experimental physics (data acquisition)
+ * Root finding techniques, used in methods for theoretical physics, quantum mechanics, electromagnetism and mechanics.
 
 In order to achieve a proper pedagogical introduction of these algorithms, it is important that students and teachers alike see how these algorithms are used to solve a variety of physics problems. The same algorithm, for example the solution of a second-order differential equation, can be used to solve the equations for the classical pendulum in a mechanics course or the (with a suitable change of variables) equations for a coupled RLC circuit in the electromagnetism course. Similarly, if students develop a program for studies of celestial bodies in the mechanics course, many of the elements of such a program can be reused in a molecular dynamics calculation in a course on statistical physics and thermal physics. The two-point boundary value problem for a buckling beam
 (discretized as an eigenvalue problem) can be reused in quantum mechanical studies of interacting electrons in oscillator traps, or just to study a particle in a box potential with varying depth and extension. 


### PR DESCRIPTION
I thought signal processing (particularly Fourier stuff) had enough applicability---and is usually glossed over enough---to warrant its own section. Please let me know if this is better suited elsewhere!

I also tried to rebuild the "pub" docs (pdf, ipython, etc.), but the makefile seems to error out on my machine even with doconce installed.